### PR TITLE
Handle case where is not possible to open the display

### DIFF
--- a/brightness-widget.lua
+++ b/brightness-widget.lua
@@ -60,6 +60,9 @@ end
 
 function Brightness:update(status)
 	local b = self:getBrightness()
+        if b == nil then
+          b = 0
+        end
 	local img = math.floor((b/100)*7)
 	self.widget:set_image(config.."/awesome.brightness-widget/icons/"..img..".png")
 end
@@ -80,7 +83,7 @@ function Brightness:set(val)
 end
 
 function Brightness:getBrightness()
-	return run(self.cmd.." "..self.get)
+	return tonumber(run(self.cmd.." "..self.get))
 end
 
 function Brightness.mt:__call(...)


### PR DESCRIPTION
This is a corner case where I'm running awesome inside a VirtualBox VM
for which the display is not really working perfectly.

```
1 manzo@archlinux ~ % xbacklight -get                                                                                               :(
RANDR Query Version returned error -1
1 manzo@archlinux ~ % xrandr --query                                                                                                :(
Can't open display
```

I hope this may be useful in other cases because an error here has
prevented all my configs to be loaded.